### PR TITLE
certifi is required for https support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ elasticsearch==6.4.0
 jsbeautifier==1.10.2
 colorama==0.4.3
 yara==1.7.7
+certifi==2019.11.28


### PR DESCRIPTION
If tested on https port, the following error will appear:
elasticsearch.exceptions.ImproperlyConfigured: Root certificates are missing for certificate validation. Either pass them in using the ca_certs parameter or install certifi to use it automatically.